### PR TITLE
env var for graph and tile cache dirs

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -34,7 +34,7 @@ const DEFAULT_SEARCH_RADIUS = 10;
 const MIN_CONFIDENCE = 0.5;
 const OPTIMIZE_GRAPH = true;
 const USE_LOCAL_CACHE = true;
-const SHST_GRAPH_CACHE_DIR = resolveHome('~/.shst/cache/graphs/');
+const SHST_GRAPH_CACHE_DIR = process.env.SHST_CACHE_DIR || resolveHome('~/.shst/cache/graphs/');
 
 
 function getOSRMDirectory() {

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -23,7 +23,7 @@ const SHST_ID_API_URL = process.env.SHST_ID_API_URL || 'https://api.sharedstreet
 const SHST_TILE_URL = process.env.SHST_TILE_URL || 'https://tiles.sharedstreets.io/';
 
 const USE_LOCAL_CACHE = true;
-const SHST_TILE_CACHE_DIR = resolveHome('~/.shst/cache/tiles/');
+const SHST_TILE_CACHE_DIR = process.env.SHST_CACHE_DIR || resolveHome('~/.shst/cache/tiles/');
 
 export enum TileType {
     REFERENCE = 'reference',


### PR DESCRIPTION
This was needed because AWS lambda supports writing only into `/tmp` dir.