### PR TITLE
ART-1434: shst matching robustness improvements

### DIFF
--- a/src/commands/match.ts
+++ b/src/commands/match.ts
@@ -872,7 +872,7 @@ async function matchLines(outFile, params, lines, flags) {
       var gisRef:SharedStreetsReference = forwardReference(line);
 			
       matchForward = await matcher.matchGeom(line);
-      if(matchForward && matchForward.score < matcher.searchRadius * 2) {
+      if(matchForward) {
         matchForwardSegments = getMatchedSegments(matchForward, gisRef);
       }
     }
@@ -885,7 +885,7 @@ async function matchLines(outFile, params, lines, flags) {
 
       var reversedLine = <turfHelpers.Feature<turfHelpers.LineString>>reverseLineString(line);
       matchBackward = await matcher.matchGeom(reversedLine);
-      if(matchBackward && matchBackward.score < matcher.searchRadius * 2) {
+      if(matchBackward) {
         matchBackwardSegments = getMatchedSegments(matchBackward, gisRef);
       }
     }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -902,8 +902,13 @@ export class Graph {
             }
     
             if(visitedEdgeList.length > 0) {
-                var startPoint = turfHelpers.point(feature.geometry.coordinates[0]);
-                var endPoint = turfHelpers.point(feature.geometry.coordinates[feature.geometry.coordinates.length - 1]);
+                // Use the first non-null point (in the matches), rather than just the first point from the raw trace
+                // This way, we are guaranteed to get a match if the OSRM matching was successful
+                var firstNonNull = 0, lastNonNull = matches['tracepoints'].length - 1
+                while (!matches['tracepoints'][firstNonNull] && firstNonNull++);
+                while (!matches['tracepoints'][lastNonNull] && lastNonNull--);
+                var startPoint = turfHelpers.point(matches['tracepoints'][firstNonNull]['location']);
+                var endPoint = turfHelpers.point(matches['tracepoints'][lastNonNull]['location']);
 
 
                 var startCandidate:PointCandidate = await this.getPointCandidateFromRefId(startPoint, visitedEdgeList[0], null);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -855,50 +855,48 @@ export class Graph {
             if(matches['matchings'] &&  matches['matchings'].length > 0) {
                 
                 var match = matches['matchings'][0];
-                if(0 < match.confidence ) {
 
-                    // this is kind of convoluted due to the sparse info returned in the OSRM annotations...
-                    // write out sequence of nodes and edges as emitted from walking OSRM-returned nodes
-                    // finding the actual posistion and directionality of the OSRM-edge within the ShSt graph 
-                    // edge means that we have to snap start/end points in the OSRM geom
-                    
-                    //console.log(JSON.stringify(match.geometry));
+                // this is kind of convoluted due to the sparse info returned in the OSRM annotations...
+                // write out sequence of nodes and edges as emitted from walking OSRM-returned nodes
+                // finding the actual posistion and directionality of the OSRM-edge within the ShSt graph 
+                // edge means that we have to snap start/end points in the OSRM geom
+                
+                //console.log(JSON.stringify(match.geometry));
 
-                    var edgeCandidates;
-                    var nodes:number[] = [];
-                    var visitedNodes:Set<number> = new Set();
-                    // ooof this is brutual -- need to unpack legs and reduce list... 
-                    for(var leg of match['legs']) {
-                        //console.log(leg['annotation']['nodes'])
-                        for(var n of leg['annotation']['nodes']){ 
-                            if(!visitedNodes.has(n) || nodes.length == 0)
-                                nodes.push(n);
+                var edgeCandidates;
+                var nodes:number[] = [];
+                var visitedNodes:Set<number> = new Set();
+                // ooof this is brutual -- need to unpack legs and reduce list... 
+                for(var leg of match['legs']) {
+                    //console.log(leg['annotation']['nodes'])
+                    for(var n of leg['annotation']['nodes']){ 
+                        if(!visitedNodes.has(n) || nodes.length == 0)
+                            nodes.push(n);
 
-                            visitedNodes.add(n);
-                        }
+                        visitedNodes.add(n);
                     }
+                }
 
-                // then group node pairs into unique edges...
-                    var previousNode = null;
-                    for(var nodeId of nodes) {
-                        if(await this.db.has('node:' + nodeId)) {
+            // then group node pairs into unique edges...
+                var previousNode = null;
+                for(var nodeId of nodes) {
+                    if(await this.db.has('node:' + nodeId)) {
 
-                            if(previousNode) {
-                                if(await this.db.has('node-pair:' + nodeId + '-' + previousNode)) {
-                                    var edges = JSON.parse(await this.db.get('node-pair:' + nodeId + '-' + previousNode));
-                                    for(var edge of edges) {
-                                        
-                                        if(!visitedEdges.has(edge))
-                                            visitedEdgeList.push(edge);
+                        if(previousNode) {
+                            if(await this.db.has('node-pair:' + nodeId + '-' + previousNode)) {
+                                var edges = JSON.parse(await this.db.get('node-pair:' + nodeId + '-' + previousNode));
+                                for(var edge of edges) {
+                                    
+                                    if(!visitedEdges.has(edge))
+                                        visitedEdgeList.push(edge);
 
-                                        visitedEdges.add(edge);
-                                    }
+                                    visitedEdges.add(edge);
                                 }
                             }
-                            previousNode = nodeId;
                         }
-                    }     
-                }
+                        previousNode = nodeId;
+                    }
+                }     
             }
     
             if(visitedEdgeList.length > 0) {

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -38,14 +38,17 @@ export async function getTilesForId(id:string) {
 }
 
 export function getTileIdsForPolygon(polygon:turfHelpers.Feature<turfHelpers.Polygon>, buffer:number=0):string[] {
+    if (polygon === null) {
+        return [];
+    } else {
+      var polyBound = bbox(polygon)
 
-    var polyBound = bbox(polygon)
-
-    var nwPoint = destination([polyBound[0],polyBound[1]], buffer, 315, {'units':'meters'});
-    var sePoint = destination([polyBound[2],polyBound[3]], buffer, 135, {'units':'meters'});
-    let bounds = [nwPoint.geometry.coordinates[0], nwPoint.geometry.coordinates[1], sePoint.geometry.coordinates[0], sePoint.geometry.coordinates[1]];
-    
-    return getTileIdsForBounds(bounds, false);
+      var nwPoint = destination([polyBound[0],polyBound[1]], buffer, 315, {'units':'meters'});
+      var sePoint = destination([polyBound[2],polyBound[3]], buffer, 135, {'units':'meters'});
+      let bounds = [nwPoint.geometry.coordinates[0], nwPoint.geometry.coordinates[1], sePoint.geometry.coordinates[0], sePoint.geometry.coordinates[1]];
+      
+      return getTileIdsForBounds(bounds, false);
+    }
   
 }
 


### PR DESCRIPTION
[Ticket](https://routereports.atlassian.net/browse/ART-1434)

I was seeing some failed matches, even when I'd expect a good match just from looking at the trace, and by running OSRM matching directly. There were quite strict constraints on post-processing the OSRM output, and so I have loosened those off a little bit to give us more robustness in the output.

I will comment on the specific individual changes.

For testing, you can use this trace and run the matching on this branch vs the main branch to see the difference:

```
docker run -it --rm -v ${PWD}:/work --env SHST_TILE_URL=https://rr-binaries.s3.eu-west-2.amazonaws.com/tiles/ shst-image match /work/test.geojson --tile-source=osm/planet-240104 --search-radius=25 --follow-line-direction
```

```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -0.2094627999999993,
            52.5977402
          ],
          [
            -0.20944320000000027,
            52.59764479999999
          ],
          [
            -0.20948560000000072,
            52.598114
          ],
          [
            -0.21030939999999987,
            52.598419199999995
          ],
          [
            -0.21161750000000076,
            52.59839629999999
          ],
          [
            -0.22327850000000107,
            52.6007805
          ],
          [
            -0.22510950000000032,
            52.60230259999999
          ],
          [
            -0.22987429999999948,
            52.60523220000001
          ],
          [
            -0.23804459999999988,
            52.60895539999999
          ],
          [
            -0.24569849999999904,
            52.61297230000001
          ],
          [
            -0.24825579999999914,
            52.614566800000006
          ],
          [
            -0.24752409999999983,
            52.614574399999995
          ],
          [
            -0.24688100000000002,
            52.61516189999999
          ],
          [
            -0.24682960000000137,
            52.6155472
          ],
          [
            -0.24776610000000016,
            52.6158524
          ],
          [
            -0.24778540000000043,
            52.61575319999999
          ]
        ]
      }
    }
  ]
}
```