### PR TITLE
ART-1476: loop through all matches

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -853,8 +853,6 @@ export class Graph {
             
             if(matches['matchings'] &&  matches['matchings'].length > 0) {
                 
-                var match = matches['matchings'][0];
-
                 // This is a bit messy - we need to go through the legs of the matched journey
                 // and find the edges that we passed through in order
                 // for each leg, iterate through the pairs of nodes and find the corresponding edge
@@ -863,29 +861,31 @@ export class Graph {
                 //console.log(JSON.stringify(match.geometry));
                 var previousEdge = null;
                 // ooof this is brutual -- need to unpack legs and reduce list... 
-                for(var leg of match['legs']) {
-                    //console.log(leg['annotation']['nodes'])
-                    const nodes = leg['annotation']['nodes']
-                    for(var i=0; i < nodes.length - 1; i++){
-                      const prev = nodes[i];
-                      const next = nodes[i + 1];
-    
-                      if(await this.db.has('node:' + next)) {
+                for (var match of matches['matchings']) {
+                  for(var leg of match['legs']) {
+                      //console.log(leg['annotation']['nodes'])
+                      const nodes = leg['annotation']['nodes']
+                      for(var i=0; i < nodes.length - 1; i++){
+                        const prev = nodes[i];
+                        const next = nodes[i + 1];
+      
+                        if(await this.db.has('node:' + next)) {
 
-                        if(prev) {
-                            if(await this.db.has('node-pair:' + next+ '-' + prev)) {
-                                var edges = JSON.parse(await this.db.get('node-pair:' + next+ '-' + prev));
-                                for(var edge of edges) {
-                                    
-                                    if (previousEdge !== edge) {
-                                        visitedEdgeList.push(edge);
-                                        previousEdge = edge;
-                                    }
-                                }
-                            }
+                          if(prev) {
+                              if(await this.db.has('node-pair:' + next+ '-' + prev)) {
+                                  var edges = JSON.parse(await this.db.get('node-pair:' + next+ '-' + prev));
+                                  for(var edge of edges) {
+                                      
+                                      if (previousEdge !== edge) {
+                                          visitedEdgeList.push(edge);
+                                          previousEdge = edge;
+                                      }
+                                  }
+                              }
+                          }
                         }
                       }
-                    }
+                  }
                 }
             }
     


### PR DESCRIPTION
Another small improvement to handle true GPS traces better.

From the [OSRM docs](https://project-osrm.org/docs/v5.24.0/api/#match-service), the match service returns any number of matched route traces. However, we were just using the first one in here. So when multiple were returned, the matching failed.

This small change loops through all the matches to build the trace, rather than just the first one.

Example trace which demonstrates a failed match on `master` and a successful match in this branch:

```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -2.5787007999999996,
            53.6112518
          ],
          [
            -2.5789664,
            53.611049699999995
          ],
          [
            -2.5790083000000013,
            53.61101149999999
          ],
          [
            -2.5790308000000004,
            53.6109924
          ],
          [
            -2.5791233,
            53.61092000000001
          ],
          [
            -2.580004,
            53.61009979999999
          ],
          [
            -2.580615799999999,
            53.60941700000001
          ],
          [
            -2.5807123000000005,
            53.6092567
          ],
          [
            -2.580751199999999,
            53.6092377
          ],
          [
            -2.5807948000000005,
            53.609172799999996
          ],
          [
            -2.5809436,
            53.60901259999999
          ],
          [
            -2.582020799999999,
            53.608222999999995
          ],
          [
            -2.5831361000000004,
            53.6075249
          ],
          [
            -2.5847523000000003,
            53.6066513
          ],
          [
            -2.585232500000001,
            53.6064529
          ],
          [
            -2.5852752000000003,
            53.606433899999985
          ],
          [
            -2.5853181000000007,
            53.6064148
          ],
          [
            -2.5853617,
            53.60639569999999
          ],
          [
            -2.5854073000000004,
            53.60637280000001
          ],
          [
            -2.585505200000001,
            53.606330899999996
          ],
          [
            -2.5863152,
            53.605896
          ],
          [
            -2.5864713000000004,
            53.60582730000001
          ],
          [
            -2.5867800999999995,
            53.60569759999999
          ],
          [
            -2.5869607999999995,
            53.6056213
          ],
          [
            -2.5878708000000006,
            53.605278
          ],
          [
            -2.5880108000000006,
            53.6051407
          ],
          [
            -2.588141400000001,
            53.6051407
          ],
          [
            -2.5880685000000008,
            53.605216999999996
          ],
          [
            -2.5875037000000005,
            53.60543439999999
          ],
          [
            -2.5871402999999997,
            53.60556030000001
          ],
          [
            -2.5869443000000003,
            53.60563280000001
          ],
          [
            -2.586742600000001,
            53.6057053
          ],
          [
            -2.5863492,
            53.605865499999986
          ],
          [
            -2.5854874000000003,
            53.60633469999998
          ],
          [
            -2.5852597,
            53.6064415
          ],
          [
            -2.5846217,
            53.60675049999999
          ],
          [
            -2.5836542,
            53.607246399999994
          ],
          [
            -2.582084900000001,
            53.60820009999999
          ],
          [
            -2.5810077000000002,
            53.60906599999999
          ],
          [
            -2.5808508000000003,
            53.60916519999999
          ],
          [
            -2.5806129,
            53.609275800000006
          ],
          [
            -2.5793380999999997,
            53.61068339999999
          ],
          [
            -2.5791285000000004,
            53.61089710000001
          ],
          [
            -2.5790184000000003,
            53.6110039
          ],
          [
            -2.5789063,
            53.61111449999999
          ],
          [
            -2.5784612000000005,
            53.61153409999999
          ],
          [
            -2.577821300000001,
            53.6122284
          ],
          [
            -2.5779099,
            53.6122322
          ]
        ]
      }
    }
  ]
}
```