### PR TITLE
Art 1457: locate command

### DIFF
--- a/src/commands/locate.ts
+++ b/src/commands/locate.ts
@@ -1,11 +1,9 @@
 import { Args, Command, Flags } from '@oclif/core'
 import { readFileSync, writeFileSync } from 'fs';
+import * as turfHelpers from '@turf/helpers';
 
 import { TilePathParams, TileType, TilePathGroup } from '../index'
 import { TileIndex } from '../index'
-import { getTilesForId } from '../tiles';
-
-import geomLength from '@turf/length';
 
 const chalk = require('chalk');
 
@@ -21,49 +19,62 @@ export default class Locate extends Command {
     out: Flags.string({char: 'o', description: 'output file'}),
     'tile-source': Flags.string({description: 'SharedStreets tile source', default: 'osm/planet-181224'}),
     'tile-hierarchy': Flags.integer({description: 'SharedStreets tile hierarchy', default: 6}),
-    'ref': Flags.string({description: 'SharedStreets reference', required: true}),
-    'offset': Flags.string({description: "SharedStreets offset", required: true}),
-    'tile-ids': Flags.string({description: "SharedStreets tile ids as JSON list", required: true})
   }
 
   static args = {
+    inFile: Args.string({name: 'JSON data file', required: true})
   }
 
   async run() {
     const {args, flags} = await this.parse(Locate)
 
+    const inFile = args.inFile;
+    const content = readFileSync(inFile);
+    const data:turfHelpers.FeatureCollection<turfHelpers.Geometry> = JSON.parse(content.toLocaleString());
+
     var outFile = flags.out;
 
+    if(!outFile) 
+      outFile = inFile;
+
+    if(outFile.toLocaleLowerCase().endsWith(".geojson"))
+      outFile = outFile.split(".").slice(0, -1).join(".");
+
     this.log(chalk.bold.keyword('green')('  🗄️  Loading SharedStreets tiles...'));
-    const tileIds = JSON.parse(flags['tile-ids']);
 
     var params = new TilePathParams();
     params.source = flags['tile-source'];
     params.tileHierarchy = flags['tile-hierarchy']
 
+    // Iterate through the items and build a set of all relevant tile ids
+    var tileIds: Set<string> = new Set();
+    for (var feature of data.features) {
+      for (var tileId of feature.properties.shst_tile_ids) {
+        tileIds.add(tileId);
+      }
+    }
+
+    // Load the tiles and index them
     var tilePathGroup = new TilePathGroup();
     tilePathGroup.setParams(params);
-    tilePathGroup.tileIds = tileIds;
+    tilePathGroup.tileIds = Array.from(tileIds);
     tilePathGroup.tileTypes = [TileType.GEOMETRY, TileType.REFERENCE];
 
     var tileIndex = new TileIndex();
 
     await tileIndex.indexTilesByPathGroup(tilePathGroup);
 
-    const ref = flags['ref'];
-    const offset = parseFloat(flags['offset']);
+    this.log(chalk.bold.keyword('green')(`  🔍  Searching data...`));
 
-    this.log(chalk.bold.keyword('green')(`  🔍  Searching data for ref=${ref} and offset=${offset}...`));
-
-    const loc = await tileIndex.geom(ref, offset, null);
-
-    if (outFile) {
-      console.log(chalk.bold.keyword('blue')('  ✏️  Writing output to: ' + outFile + '.out.geojson'));
-      var jsonOut = JSON.stringify(loc);
-      writeFileSync(outFile + '.out.geojson', jsonOut);
+    for (var feature of data.features) {
+      const ref = feature.properties.shst_ref;
+      const offset = feature.properties.shst_offset;
+      const geom = await tileIndex.geom(ref, offset, null);
+      feature.geometry = geom.geometry;
     }
 
-    this.log(chalk.bold.keyword('blue')(`  🗺️  Located point:\n${JSON.stringify(loc, null, 4)}`));
-
+    console.log(chalk.bold.keyword('blue')('  ✏️  Writing output to: ' + outFile + '.out.geojson'));
+    var jsonOut = JSON.stringify(data);
+    writeFileSync(outFile + '.out.geojson', jsonOut);
   }
 }

--- a/src/commands/locate.ts
+++ b/src/commands/locate.ts
@@ -1,0 +1,69 @@
+import { Args, Command, Flags } from '@oclif/core'
+import { readFileSync, writeFileSync } from 'fs';
+
+import { TilePathParams, TileType, TilePathGroup } from '../index'
+import { TileIndex } from '../index'
+import { getTilesForId } from '../tiles';
+
+import geomLength from '@turf/length';
+
+const chalk = require('chalk');
+
+export default class Locate extends Command {
+  static description = 'returns a geospatial location given a shst reference and offset'
+
+  static examples = [
+    ``,
+  ]
+
+  static flags = {
+    help: Flags.help({char: 'h'}),
+    out: Flags.string({char: 'o', description: 'output file'}),
+    'tile-source': Flags.string({description: 'SharedStreets tile source', default: 'osm/planet-181224'}),
+    'tile-hierarchy': Flags.integer({description: 'SharedStreets tile hierarchy', default: 6}),
+    'ref': Flags.string({description: 'SharedStreets reference', required: true}),
+    'offset': Flags.string({description: "SharedStreets offset", required: true}),
+    'tile-ids': Flags.string({description: "SharedStreets tile ids as JSON list", required: true})
+  }
+
+  static args = {
+  }
+
+  async run() {
+    const {args, flags} = await this.parse(Locate)
+
+    var outFile = flags.out;
+
+    this.log(chalk.bold.keyword('green')('  🗄️  Loading SharedStreets tiles...'));
+    const tileIds = JSON.parse(flags['tile-ids']);
+
+    var params = new TilePathParams();
+    params.source = flags['tile-source'];
+    params.tileHierarchy = flags['tile-hierarchy']
+
+    var tilePathGroup = new TilePathGroup();
+    tilePathGroup.setParams(params);
+    tilePathGroup.tileIds = tileIds;
+    tilePathGroup.tileTypes = [TileType.GEOMETRY, TileType.REFERENCE];
+
+    var tileIndex = new TileIndex();
+
+    await tileIndex.indexTilesByPathGroup(tilePathGroup);
+
+    const ref = flags['ref'];
+    const offset = parseFloat(flags['offset']);
+
+    this.log(chalk.bold.keyword('green')(`  🔍  Searching data for ref=${ref} and offset=${offset}...`));
+
+    const loc = await tileIndex.geom(ref, offset, null);
+
+    if (outFile) {
+      console.log(chalk.bold.keyword('blue')('  ✏️  Writing output to: ' + outFile + '.out.geojson'));
+      var jsonOut = JSON.stringify(loc);
+      writeFileSync(outFile + '.out.geojson', jsonOut);
+    }
+
+    this.log(chalk.bold.keyword('blue')(`  🗺️  Located point:\n${JSON.stringify(loc, null, 4)}`));
+
+  }
+}

--- a/src/commands/match.ts
+++ b/src/commands/match.ts
@@ -735,6 +735,8 @@ async function matchLines(outFile, params, lines, flags) {
       segmentGeom.properties['startSideOfStreet'] = path.startPoint.sideOfStreet;
       segmentGeom.properties['endSideOfStreet'] = path.endPoint.sideOfStreet;
 
+      segmentGeom.properties['tileIds'] = path.tileIds;
+
       if(flags['side-of-street-field'] && path.originalFeature.properties[flags['side-of-street-field']]) {
         var sideOfStreetValue = path.originalFeature.properties[flags['side-of-street-field']].toLocaleLowerCase();
         if(flags['left-side-of-street-value'].toLocaleLowerCase() === sideOfStreetValue) {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -318,6 +318,7 @@ export class PathCandidate {
 	matchedPath:turfHelpers.Feature<turfHelpers.Geometry>;
 
 	sideOfStreet:ReferenceSideOfStreet;
+  tileIds:string[];
 
 
     toDebugView():turfHelpers.FeatureCollection<turfHelpers.Geometry> {
@@ -911,6 +912,7 @@ export class Graph {
                 pathCandidate.score = match.confidence;
                 pathCandidate.originalFeature = feature;
                 pathCandidate.matchedPath = turfHelpers.feature(match.geometry);
+                pathCandidate.tileIds = this.tilePathGroup.tileIds
 
                 //console.log(JSON.stringify(pathCandidate.matchedPath));
 

--- a/src/tile_index.ts
+++ b/src/tile_index.ts
@@ -434,7 +434,7 @@ export class TileIndex {
             if(p1 == null && p2 == null) {
                 return geomFeature;
             }
-            else if(p1 && p2 == null) {
+            else if(p1 != null && p2 == null) {
                 return along(geomFeature, p1, {"units":"meters"});
             } 
             else if(p1 != null && p2 != null) {


### PR DESCRIPTION
[Ticket](https://routereports.atlassian.net/browse/ART-1457)

Introduces a new command `locate` which takes shared street reference and offset and returns the geospatial location. It also takes a list of the relevant tile ids which must be provided by the user.

Also in this PR, `tileIds` are outputted from the matching service, so they can be tracked and then used to find the geospatial location further down the pipeline.

To test, build and then run:
```
docker run -it --rm -v ${PWD}:/work --env SHST_TILE_URL=https://rr-binaries.s3.eu-west-2.amazonaws.com/tiles/ shst-image locate --tile-source=osm/planet-240104 --ref=07b6b0522a12bc8654c0600539636cea --offset=10.1 --tile-ids='["12-2045-1366","12-2045-1367"]'
```