### PR TITLE
Art 2295: Use buffered polygon for tiles

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1002,6 +1002,7 @@ export class Graph {
             }
         }
         catch(e) {
+      console.error(e)
             // no-op failed to match
         }
         

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -5,6 +5,7 @@ import {SharedStreetsIntersection, SharedStreetsGeometry } from 'sharedstreets-t
 import * as turfHelpers from '@turf/helpers';
 import bbox from "@turf/bbox";
 import destination from '@turf/destination';
+import buffer from '@turf/buffer';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 
 import { getJson, getPbf, resolveHome } from "./util";
@@ -257,11 +258,12 @@ export class TilePathGroup extends TilePathParams  {
         this.addTileId(path.tileId);
     }
 
-    static fromPolygon(polygon:turfHelpers.Feature<turfHelpers.Polygon>, buffer:number, params:TilePathParams):TilePathGroup {
+    static fromPolygon(polygon:turfHelpers.Feature<turfHelpers.Polygon>, buf:number, params:TilePathParams):TilePathGroup {
 
         var tilePathGroup = new TilePathGroup();
         tilePathGroup.setParams(params);
-        tilePathGroup.tileIds = getTileIdsForPolygon(polygon);
+        var bufferedPolygon = buffer(polygon, buf, {units: "metres"})
+        tilePathGroup.tileIds = getTileIdsForPolygon(bufferedPolygon);
 
         return tilePathGroup;
     }


### PR DESCRIPTION
### **User description**
[Ticket](https://routereports.atlassian.net/jira/software/c/projects/ART/boards/2?selectedIssue=ART-2295)

This solves a source of matching errors (both in the new and the production pipeline).

Where data is at the edge of a tile, the shst reference information might be in the neighbouring and might not be fetched. We can get errors when we search for the reference and find it is not present.

There was a method to solve this by putting a 1km buffer around the raw polygon when grabbing tiles, but the buffering wasn't actually applied in the function.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes tile matching errors by buffering polygons.

- Adds a buffer to polygons when fetching tiles.

- Improves error handling by logging exceptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph.ts</strong><dd><code>Add error logging for matching failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/graph.ts

<li>Added a console error log for exception handling.<br> <li> Improves debugging by logging errors during matching.


</details>


  </td>
  <td><a href="https://github.com/RouteReports/sharedstreets-js/pull/14/files#diff-940e3850dd4ed0916f6f1d4da40fbb8fd5be5f0ac0c826437d5a39c0468fb020">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tiles.ts</strong><dd><code>Use buffered polygons for tile fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tiles.ts

<li>Added <code>buffer</code> function to apply polygon buffering.<br> <li> Modified <code>fromPolygon</code> to use buffered polygons for tile IDs.<br> <li> Improved tile fetching accuracy by using buffered polygons.


</details>


  </td>
  <td><a href="https://github.com/RouteReports/sharedstreets-js/pull/14/files#diff-259c479aefab0e7c1b29e94f554229da7613123d2cd8a926c31d604ec2982e98">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>